### PR TITLE
Fix typo in the CDC stack description

### DIFF
--- a/ChangeDataCapture/template.yml
+++ b/ChangeDataCapture/template.yml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
     Stack that deploys one Lambda function that reads from DynamoDB Stream and replicates the changes to Target DynamoDB Table cross account 
-    Functoion is triggered by DynamoDB stream
+    Function is triggered by DynamoDB stream
     
 Parameters:
   TargetDynamoDBTable: 


### PR DESCRIPTION
Fixing a typo in the CDC stack description, replacing _Functoion_ by _Function_ 