### PR TITLE
Fix typo on put log event permission

### DIFF
--- a/ChangeDataCapture/template.yml
+++ b/ChangeDataCapture/template.yml
@@ -61,7 +61,7 @@ Resources:
                   Action:
                     - logs:CreateLogGroup
                     - logs:CreateLogStream
-                    - logs:PutLogEvent
+                    - logs:PutLogEvents
                   Resource: '*'
             Environment:
                 Variables:


### PR DESCRIPTION
*Description of changes:*

`logs:PutLogEvent` permissions is missing a `s` at the end.
