### PR TITLE
Fix lambda binary handling

### DIFF
--- a/ChangeDataCapture/functions/ReplayFromStream.py
+++ b/ChangeDataCapture/functions/ReplayFromStream.py
@@ -3,7 +3,7 @@ import os
 import json
 import boto3
 
-def decode_bytes_if_present(items_by_type):
+def decode_bytes_if_present(items_by_type: dict) -> None:
     # Look for binary values, b64 decode them back into bytes
     for key, value_dict in items_by_type.items():
         for value_type, value in value_dict.items():


### PR DESCRIPTION
*Issue #, if available:* [10](https://github.com/aws-samples/cross-account-amazon-dynamodb-replication/issues/10) by @Fasopus

*Description of changes:* [copied from issue]

> The dynamodb stream is emitting its changes in json string format, with binary values being base64 encoded. However when performing the put_item command through boto, these strings are assumed to be un-encoded and go through an additional base64 encoding. I was able to resolve this by transforming the binary objects into their bytes representations before sending them through boto

I also encountered this issue when I pasted this repo's lambda code into my project. This solution fixed `put_item` handling for me (although I didn't test the `delete_item` portion since the DB didn't have binary keys).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

